### PR TITLE
improve performance by using tensor multiplication

### DIFF
--- a/src/main/java/org/redfx/strange/BlockGate.java
+++ b/src/main/java/org/redfx/strange/BlockGate.java
@@ -40,12 +40,13 @@ import java.util.stream.IntStream;
  *
  * A Gate describes an operation on one or more qubits.
  * @author johan
+ * @param <T> Type of the Gate
  */
-public class BlockGate<T> implements Gate {
+public class BlockGate<T extends Gate> implements Gate {
 
     protected Block block;
     protected int idx;
-    private boolean inverse = false;
+    protected boolean inverse = false;
     
     protected BlockGate() {
     }
@@ -123,21 +124,38 @@ public class BlockGate<T> implements Gate {
         Complex[][] answer = block.getMatrix(qee);
         if (inverse) {
             answer = Complex.conjugateTranspose(answer);
+            Complex.printMatrix(answer);
         }
         return answer;
     }
     
-    public T inverse() {
-        this.inverse = !inverse;
-        return (T)this;
+    @Override
+    public void setInverse(boolean inv) {
+        this.inverse = inv;
     }
     
+    public T inverse() {
+        setInverse(true);
+        return (T) this;
+    }
+    
+    @Override
     public int getSize() {
         return block.getNQubits();
     }
-    
+        
+    @Override
+    public boolean hasOptimization() {
+        return true;
+    }
+
+    @Override
+    public Complex[] applyOptimize(Complex[] v) {
+        return block.applyOptimize(v, inverse);
+    }
+
     @Override public String toString() {
-        return "Gate for block "+block+", size = "+getSize();
+        return "Gate for block "+block+", size = "+getSize()+", inv = "+inverse;
     }
 
     

--- a/src/main/java/org/redfx/strange/Complex.java
+++ b/src/main/java/org/redfx/strange/Complex.java
@@ -154,15 +154,9 @@ public final class Complex {
      * @return
      */
     public static Complex[][] tensor(Complex[][] a, Complex[][] b) {
-        Complex.printMatrix(a);
-        Complex.printMatrix(b);
         int d1 = a.length;
         int d2 = b.length;
-       // System.err.println("tensor for "+d1+" and "+d2+", new dim will be "+(d1*d2));
-        //Computations.printMemory();
         Complex[][] result = new Complex[d1 * d2][d1 * d2];
-        //System.err.println("allocated memory");
-// Computations.printMemory();
         for (int rowa = 0; rowa < d1; rowa++) {
             for (int cola = 0; cola < d1; cola++) {
                 for (int rowb = 0; rowb < d2; rowb++) {
@@ -176,9 +170,6 @@ public final class Complex {
                 }
             }
         }
-        //System.err.println("tensor created new matrix");
-        //Computations.printMemory();
-
         return result;
     }
     static int zCount = 0;
@@ -189,7 +180,6 @@ public final class Complex {
     }
     
     public static Complex[][] slowmmul(Complex[][] a, Complex[][] b) {
-     //   System.err.println("slowmul");
         int arow = a.length;
         int acol = a[0].length;
         int brow = b.length;
@@ -210,78 +200,8 @@ public final class Complex {
 
         return answer;
     }
-        
-    private static Complex[][] fastmmul(Complex[][] a, Complex[][] b) {
-        /*
-        long l0 = System.currentTimeMillis();
-        int arow = a.length;
-        int acol = a[0].length;
-        int brow = b.length;
-        int bcol = b[0].length;
-        int am = 0;
-        if (acol != brow) {
-            throw new RuntimeException("#cols a " + acol + " != #rows b " + brow);
-        }
-        Complex[][] answer = new Complex[arow][bcol];
-        double[][] ar = new double[arow][acol];
-        double[][] ai = new double[arow][acol];
-        double[][] br = new double[brow][bcol];
-        double[][] bi = new double[brow][bcol];
-        dbg("start for loop");
-        for (int i = 0; i < arow; i++) {
-            for (int j = 0; j < bcol; j++) {
-                Complex el = new Complex(0., 0.);
-                double newr = 0;
-                double newi = 0;
-                boolean zero = true;
-                for (int k = 0; k < acol; k++) {
-                    if (j == 0) {
-                        ar[i][k] = a[i][k].r;
-                        ai[i][k] = a[i][k].i;
-                    }
-                    if (i == 0) {
-                        br[k][j] = b[k][j].r;
-                        bi[k][j] = b[k][j].i;
-                    }
-                }
-                if (zero) {
-                    answer[i][j] = Complex.ZERO;
-                    zCount++;
-                } else {
-                    answer[i][j] = Complex.ZERO;
-                    nzCount++;
-                }
 
-                //      System.err.println("ANSWER["+i+"]["+j+"] = "+answer[i][j]);
-
-            }
-        }
-        //     if (1 < 2) System.exit(0);
-        long l1 = System.currentTimeMillis();
-        dbg("mulitply matrix " + arow + ", " + acol + ", " + bcol + " took " + (l1 - l0) + " zc = " + zCount + " and nzc = " + nzCount + " and am = " + am);
-        INDArray n_ar = Nd4j.create(ar);
-        INDArray n_ai = Nd4j.create(ai);
-        INDArray n_br = Nd4j.create(br);
-        INDArray n_bi = Nd4j.create(bi);
-        INDArray n_r = n_ar.mmul(n_br).sub(n_ai.mmul(n_bi));
-        INDArray n_i = n_ai.mmul(n_br).add(n_ar.mmul(n_bi));
-//        System.err.println("ar = "+n_ar);
-//        System.err.println("br = "+n_br);
-//        System.err.println("nr = "+n_r);
-//        System.err.println("ni = "+n_i);
-        for (int i = 0; i < acol; i++) {
-            for (int j = 0; j < brow; j++) {
-                answer[i][j] = new Complex(n_r.getDouble(i, j), n_i.getDouble(i, j));
-//                                System.err.println("NDANSWER["+i+"]["+j+"] = "+answer[i][j]);
-
-            }
-        }
-        return answer;
-*/
-        throw new RuntimeException ("Fast multiplication not available");
-    }
-
-    static Complex[][] conjugateTranspose(Complex[][] src) {
+    public static Complex[][] conjugateTranspose(Complex[][] src) {
         int d0 = src.length;
         int d1 = src[0].length;
         Complex[][] answer = new Complex[d1][d0];
@@ -417,9 +337,16 @@ public final class Complex {
         }
     }
 
+ 
     @Override
     public String toString() {
-        return "(" + this.r + ", " + this.i + ")";
+        double mr = this.r;
+        double mi = this.i;
+        if (Math.abs(mr) < 1e-7) mr = 0;
+        if (Math.abs(mi) < 1e-7) mi = 0;
+        if (Math.abs(mr) > .999999) mr = 1;
+        if (Math.abs(mi) > .999999) mi = 1;
+        return "(" + mr + ", " + mi + ")";
     }
-    
+
 }

--- a/src/main/java/org/redfx/strange/ControlledBlockGate.java
+++ b/src/main/java/org/redfx/strange/ControlledBlockGate.java
@@ -37,13 +37,12 @@ import org.redfx.strange.local.Computations;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  *
  * A Gate describes an operation on one or more qubits.
  * @author johan
+ * @param <T> type of the Block
  */
 public class ControlledBlockGate<T> extends BlockGate {
 
@@ -147,7 +146,7 @@ public class ControlledBlockGate<T> extends BlockGate {
     public Complex[][] getMatrix() {
         return getMatrix(null);
     }
-    
+
     @Override
     public Complex[][] getMatrix(QuantumExecutionEnvironment qee) {
         if (matrix == null) {
@@ -191,30 +190,35 @@ public class ControlledBlockGate<T> extends BlockGate {
         }
         return matrix;
     }
+    
+    @Override
+    public boolean hasOptimization() {
+        return true;
+    }
+
+    @Override
+    public Complex[] applyOptimize(Complex[] v) {
+        int size = v.length;
+        Complex[] answer = new Complex[size];
+        int dim = size / 2;
+        Complex[] oldv = new Complex[dim];
+        for (int i = 0; i < dim; i++) {
+            oldv[i] = v[i + dim];
+        }
+        Complex[] p2 = block.applyOptimize(oldv, inverse);
+        for (int i = 0; i < dim; i++) {
+            answer[i] = v[i];
+            answer[dim + i] = p2[i];
+        }
+        return answer;
+    }
 
     public int getSize() {
         return block.getNQubits()+1;
     }
     
     @Override public String toString() {
-        return "CGate for "+super.toString();
-    }
-
-    void printMemory() {
-        if (1 < 2) return;
-        Runtime rt = Runtime.getRuntime();
-        long fm = rt.freeMemory()/1024;
-        long mm = rt.maxMemory()/1024;
-        long tm = rt.totalMemory()/1024;
-        long um = tm - fm;
-        System.err.println("free = "+fm+", mm = "+mm+", tm = "+tm+", used = "+um);
-        System.err.println("now gc...");
-        System.gc();
-        fm = rt.freeMemory()/1024;
-        mm = rt.maxMemory()/1024;
-        tm = rt.totalMemory()/1024;
-        um = tm - fm;
-        System.err.println("free = "+fm+", mm = "+mm+", tm = "+tm+", used = "+um);
+        return "ControlledGate for "+super.toString();
     }
     
 }

--- a/src/main/java/org/redfx/strange/Gate.java
+++ b/src/main/java/org/redfx/strange/Gate.java
@@ -101,9 +101,28 @@ public interface Gate {
     
     public Complex[][] getMatrix();
     
+    /**
+     * Return the number of qubits that are affected by this gate
+     * @return 
+     */
+    public int getSize();
+    
     default public Complex[][] getMatrix(QuantumExecutionEnvironment qee) {
         return getMatrix();
     }
-
+    
+    default public boolean hasOptimization() {
+        return false;
+    }
+    
+    default public Complex[] applyOptimize(Complex[] v) {
+        return null;
+    }
+    
+    /** 
+     * Defines whether or not this gate should be inversed
+     * @param inv 
+     */
+    void setInverse(boolean inv);
     
 }

--- a/src/main/java/org/redfx/strange/Step.java
+++ b/src/main/java/org/redfx/strange/Step.java
@@ -136,6 +136,12 @@ public class Step {
         return this.program;
     }
 
+    public void setInverse(boolean val) {
+        for (Gate g: gates) {
+            g.setInverse(val);
+        }
+    }
+    
     private void verifyUnique (Gate gate) {
         for (Gate g: gates) {
             long overlap = g.getAffectedQubitIndexes().stream().filter(gate.getAffectedQubitIndexes()::contains).count();

--- a/src/main/java/org/redfx/strange/gate/Add.java
+++ b/src/main/java/org/redfx/strange/gate/Add.java
@@ -64,7 +64,7 @@ public class Add extends BlockGate<Add> {
         this.block = cache.get(hash);
         if (this.block == null) {
             this.block = createBlock(x0, x1, y0, y1);
-            cache.put(hash, block);
+        //    cache.put(hash, block);
         } 
         setBlock(block);
        

--- a/src/main/java/org/redfx/strange/gate/AddInteger.java
+++ b/src/main/java/org/redfx/strange/gate/AddInteger.java
@@ -65,7 +65,7 @@ public class AddInteger extends BlockGate<AddInteger> {
         this.block = cache.get(hash);
         if (this.block == null) {
             this.block = createBlock(x0, x1, num);
-            cache.put(hash, block);
+   //         cache.put(hash, block);
         }
         setBlock(block);
        

--- a/src/main/java/org/redfx/strange/gate/AddModulus.java
+++ b/src/main/java/org/redfx/strange/gate/AddModulus.java
@@ -79,7 +79,12 @@ public class AddModulus extends BlockGate<AddModulus> {
         this.block = cache.get(hash);
         if (this.block == null) {
             this.block = createBlock(x0, x1, y0, y1, N);
-            cache.put(hash, block);
+       //     cache.put(hash, block);
+//            System.err.println("ADDMODULUS CREATED for hash = "+hash+
+//                    "x0 = "+x0+", x1 = "+x1+", y0 = "+y0+", y1 = "+y1+", N = "+N);
+        } else {
+//            System.err.println("ADDMODULUS CACHED for hash = "+hash+
+//                    "x0 = "+x0+", x1 = "+x1+", y0 = "+y0+", y1 = "+y1+", N = "+N);
         }
         setBlock(block);
     }

--- a/src/main/java/org/redfx/strange/gate/Cr.java
+++ b/src/main/java/org/redfx/strange/gate/Cr.java
@@ -74,7 +74,6 @@ public class Cr extends TwoQubitGate {
         {Complex.ZERO,Complex.ZERO,Complex.ONE,Complex.ZERO},
         {Complex.ZERO,Complex.ZERO,Complex.ZERO,new Complex(ar, ai)}        
         };
-       // Complex.printMatrix(matrix);
     }
     public Cr(int a, int b, int base, int pow) {
         this(a,b, Math.PI*2/Math.pow(base, pow));
@@ -84,6 +83,14 @@ public class Cr extends TwoQubitGate {
     @Override
     public Complex[][] getMatrix() {
         return matrix;
+    }
+    
+    @Override 
+    public void setInverse(boolean inv) {
+        if (inv) {
+            Complex[][] m = getMatrix();
+            this.matrix = Complex.conjugateTranspose(m);
+        }
     }
 
     @Override public String getCaption() {

--- a/src/main/java/org/redfx/strange/gate/Fourier.java
+++ b/src/main/java/org/redfx/strange/gate/Fourier.java
@@ -52,12 +52,14 @@ public class Fourier extends BlockGate {
      * @param idx the index of the first qubit in the circuit affected by this gate
      */
     public Fourier(int dim, int idx) {
-        super(new Block("Fourier", dim), idx);
-        this.dim = dim;
-        this.size = 1 <<dim;
-      //  System.err.println("Created a fourier block");
+        this("Fourier", dim, idx);
     }
     
+    public Fourier(String name, int dim, int idx) {
+         super(new Block(name, dim), idx);
+        this.dim = dim;
+        this.size = 1 <<dim;
+    }
     
     @Override
     public Complex[][] getMatrix() {
@@ -66,8 +68,6 @@ public class Fourier extends BlockGate {
     
     @Override
     public Complex[][] getMatrix(QuantumExecutionEnvironment eqq) {
-      //  System.err.println("Get fourier matrix");
-        //Thread.dumpStack();
 
         if (matrix == null) {
             double omega = Math.PI*2/size;
@@ -87,6 +87,21 @@ public class Fourier extends BlockGate {
     }
 
     @Override
+    public void setInverse(boolean v) {
+        if (v) {
+            Complex[][] m = getMatrix();
+            this.matrix = Complex.conjugateTranspose(m);
+        }
+    }
+
+    @Override
+    public Fourier inverse() {
+        Complex[][] m = getMatrix();
+        this.matrix = Complex.conjugateTranspose(m);
+        return this;
+    }
+    
+    @Override
     public List<Integer> getAffectedQubitIndexes() {
         return IntStream.range(idx, idx+dim).boxed().collect(Collectors.toList());
     }
@@ -94,5 +109,10 @@ public class Fourier extends BlockGate {
     @Override
     public int getHighestAffectedQubitIndex() {
         return dim+idx-1;
+    }
+    
+    @Override
+    public boolean hasOptimization() {
+        return false; // for now, we calculate the matrix
     }
 }

--- a/src/main/java/org/redfx/strange/gate/InvFourier.java
+++ b/src/main/java/org/redfx/strange/gate/InvFourier.java
@@ -43,8 +43,7 @@ public class InvFourier extends Fourier {
      * @param idx the index of the first qubit in the circuit affected by this gate
      */
     public InvFourier(int size, int idx) {
-        super(size, idx);
-      //  super(new Block("Fourier", size), idx);
+        super("InvFourier", size, idx);
     }
     
     @Override
@@ -87,7 +86,11 @@ public class InvFourier extends Fourier {
                 }
             }
         }
-        Complex.printMatrix(matrix);
         return matrix;
+    }
+    
+    @Override
+    public boolean hasOptimization() {
+        return false;
     }
 }

--- a/src/main/java/org/redfx/strange/gate/Mul.java
+++ b/src/main/java/org/redfx/strange/gate/Mul.java
@@ -79,7 +79,6 @@ public class Mul extends BlockGate<Mul> {
         }
 
         for (int i = x0; i < x1+1; i++) {
-            System.err.println("swap "+i+" with "+(i+size));
             answer.addStep(new Step (new Swap(i, i + size)));
         }
 

--- a/src/main/java/org/redfx/strange/gate/Oracle.java
+++ b/src/main/java/org/redfx/strange/gate/Oracle.java
@@ -60,7 +60,12 @@ public class Oracle implements Gate {
             setAdditionalQubit(i,i);
         }
     }
-
+ 
+    @Override
+    public int getSize() {
+        return span;
+    }
+    
     public void setCaption(String c) {
         this.caption = c;
     }
@@ -124,6 +129,13 @@ public class Oracle implements Gate {
                     matrix[i][j] = Complex.ZERO;
                 }
             }
+        }
+    }
+
+    @Override
+    public void setInverse(boolean inv) {
+        if (inv) {
+            this.matrix = Complex.conjugateTranspose(matrix);
         }
     }
 }

--- a/src/main/java/org/redfx/strange/gate/PermutationGate.java
+++ b/src/main/java/org/redfx/strange/gate/PermutationGate.java
@@ -118,6 +118,15 @@ public class PermutationGate implements Gate {
     }
     
     @Override
+    public int getSize() {
+        return 2;
+    }
+    
+    @Override public void setInverse(boolean v) {
+        // NOP
+    }
+    
+    @Override
     public String toString() {
         return "Perm "+a+", "+b;
     }

--- a/src/main/java/org/redfx/strange/gate/ProbabilitiesGate.java
+++ b/src/main/java/org/redfx/strange/gate/ProbabilitiesGate.java
@@ -42,10 +42,18 @@ public class ProbabilitiesGate extends InformalGate {
     public String getCaption() {
         return "P";
     }
-
+ 
+    @Override
+    public int getSize() {
+        return -1;
+    }
+    
     @Override
     public String getName() {
         return "Probabilities";
     }
-
+    
+    @Override public void setInverse(boolean v) {
+        // NOP
+    }
 }

--- a/src/main/java/org/redfx/strange/gate/R.java
+++ b/src/main/java/org/redfx/strange/gate/R.java
@@ -40,7 +40,7 @@ import org.redfx.strange.Complex;
  */
 public class R extends SingleQubitGate {
     
-    final Complex[][] matrix;
+    Complex[][] matrix;
     private final double expv;
     private int pow = -1;
     
@@ -58,6 +58,12 @@ public class R extends SingleQubitGate {
     @Override
     public Complex[][] getMatrix() {
         return matrix;
+    }
+    
+    @Override
+    public void setInverse(boolean v) {
+        super.setInverse(v);
+        matrix = Complex.conjugateTranspose(matrix);
     }
 
     @Override public String getCaption() { 

--- a/src/main/java/org/redfx/strange/gate/SingleQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/SingleQubitGate.java
@@ -45,6 +45,7 @@ import java.util.List;
 public abstract class SingleQubitGate implements Gate {
     
     private int idx;
+    private boolean inverse;
     
     public SingleQubitGate() {}
     
@@ -92,7 +93,18 @@ public abstract class SingleQubitGate implements Gate {
         return "SingleQubit";
     }
     
+    @Override
+    public int getSize() {
+        return 1;
+    }
+    
+    @Override
     public abstract Complex[][] getMatrix();
+    
+    @Override
+    public void setInverse(boolean v) {
+        this.inverse = v;
+    }
     
     @Override public String toString() {
         return "Gate with index "+idx+" and caption "+getCaption();

--- a/src/main/java/org/redfx/strange/gate/Toffoli.java
+++ b/src/main/java/org/redfx/strange/gate/Toffoli.java
@@ -64,7 +64,17 @@ public class Toffoli extends ThreeQubitGate {
     public Complex[][] getMatrix() {
         return matrix;
     }
-
+ 
+    @Override
+    public int getSize() {
+        return 3;
+    }
+    
+        
+    @Override public void setInverse(boolean v) {
+        // NOP
+    }
+    
     @Override public String getCaption() {
         return "CCnot";
     }

--- a/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
@@ -47,6 +47,7 @@ public abstract class TwoQubitGate implements Gate {
     private int first;
     private int second;
     private int highest = -1;
+    private boolean inverse;
     
     public TwoQubitGate() {}
     
@@ -104,7 +105,16 @@ public abstract class TwoQubitGate implements Gate {
     public String getGroup() {
         return "TwoQubit";
     }
+     
+    @Override
+    public int getSize() {
+        return 2;
+    }
     
+    @Override
+    public void setInverse(boolean v) {
+        this.inverse = v;
+    }
     
     @Override public String toString() {
         return "Gate acting on qubits "+first+" and "+second+" and caption "+getCaption();

--- a/src/main/java/org/redfx/strange/local/Computations.java
+++ b/src/main/java/org/redfx/strange/local/Computations.java
@@ -56,49 +56,50 @@ import org.redfx.strange.QuantumExecutionEnvironment;
  * @author johan
  */
 public class Computations {
-        
-    private static boolean debug = false;
-    static void dbg (String s) {
+
+    private static final boolean debug = false;
+
+    static void dbg(String s) {
         if (debug) {
-            System.err.println("[DBG] " + System.currentTimeMillis()%100000+": "+s);
+            System.err.println("[DBG] " + System.currentTimeMillis() % 100000 + ": " + s);
         }
     }
-    
+
     public static Complex[][] calculateStepMatrix(List<Gate> gates, int nQubits, QuantumExecutionEnvironment qee) {
         long l0 = System.currentTimeMillis();
         Complex[][] a = new Complex[1][1];
         a[0][0] = Complex.ONE;
-        int idx = nQubits-1;
+        int idx = nQubits - 1;
         while (idx >= 0) {
             final int cnt = idx;
             Gate myGate = gates.stream()
                     .filter(
-                   // gate -> gate.getAffectedQubitIndex().contains(cnt)
-                        gate -> gate.getHighestAffectedQubitIndex() == cnt )
+                            // gate -> gate.getAffectedQubitIndex().contains(cnt)
+                            gate -> gate.getHighestAffectedQubitIndex() == cnt)
                     .findFirst()
                     .orElse(new Identity(idx));
-            dbg("stepmatrix, cnt = "+cnt+", idx = "+idx+", myGate = "+myGate);
+            dbg("stepmatrix, cnt = " + cnt + ", idx = " + idx + ", myGate = " + myGate);
             if (myGate instanceof BlockGate) {
-                dbg("calculateStepMatrix for blockgate "+myGate+" of class "+myGate.getClass());
-                BlockGate sqg = (BlockGate)myGate;
+                dbg("calculateStepMatrix for blockgate " + myGate + " of class " + myGate.getClass());
+                BlockGate sqg = (BlockGate) myGate;
                 a = tensor(a, sqg.getMatrix(qee));
-                dbg("calculateStepMatrix for blockgate calculated "+myGate);
+                dbg("calculateStepMatrix for blockgate calculated " + myGate);
 
-                idx = idx - sqg.getSize()+1;
+                idx = idx - sqg.getSize() + 1;
             }
             if (myGate instanceof SingleQubitGate) {
-                SingleQubitGate sqg = (SingleQubitGate)myGate;
+                SingleQubitGate sqg = (SingleQubitGate) myGate;
                 a = tensor(a, sqg.getMatrix());
             }
             if (myGate instanceof TwoQubitGate) {
-                TwoQubitGate tqg = (TwoQubitGate)myGate;
+                TwoQubitGate tqg = (TwoQubitGate) myGate;
                 a = tensor(a, tqg.getMatrix());
                 idx--;
             }
             if (myGate instanceof ThreeQubitGate) {
-                ThreeQubitGate tqg = (ThreeQubitGate)myGate;
+                ThreeQubitGate tqg = (ThreeQubitGate) myGate;
                 a = tensor(a, tqg.getMatrix());
-                idx = idx-2;
+                idx = idx - 2;
             }
             if (myGate instanceof PermutationGate) {
                 throw new RuntimeException("No perm allowed ");
@@ -112,22 +113,29 @@ public class Computations {
         long l1 = System.currentTimeMillis();
         return a;
     }
-    
+
     /**
      * decompose a Step into steps that can be processed without permutations
+     *
      * @param s
-     * @return 
+     * @return
      */
     public static List<Step> decomposeStep(Step s, int nqubit) {
         ArrayList<Step> answer = new ArrayList<>();
         answer.add(s);
         List<Gate> gates = s.getGates();
 
-        if (gates.isEmpty()) return answer;
+        if (gates.isEmpty()) {
+            return answer;
+        }
         boolean simple = gates.stream().allMatch(g -> g instanceof SingleQubitGate);
-        if (simple) return answer;
+        if (simple) {
+            return answer;
+        }
         // if only 1 gate, which is an oracle, return as well
-        if ((gates.size() ==1) && (gates.get(0) instanceof Oracle)) return answer;
+        if ((gates.size() == 1) && (gates.get(0) instanceof Oracle)) {
+            return answer;
+        }
         // at least one non-singlequbitgate
         List<Gate> firstGates = new ArrayList<>();
         for (Gate gate : gates) {
@@ -137,7 +145,7 @@ public class Computations {
             }
             if (gate instanceof BlockGate) {
                 if (gate instanceof ControlledBlockGate) {
-                    processBlockGate ((ControlledBlockGate)gate, answer) ;
+                    processBlockGate((ControlledBlockGate) gate, answer);
                 }
                 firstGates.add(gate);
             } else if (gate instanceof SingleQubitGate) {
@@ -147,12 +155,14 @@ public class Computations {
                 int first = tqg.getMainQubitIndex();
                 int second = tqg.getSecondQubitIndex();
                 if ((first >= nqubit) || (second >= nqubit)) {
-                    throw new IllegalArgumentException ("Step "+s+" uses a gate with invalid index "+first+" or "+second);
+                    throw new IllegalArgumentException("Step " + s + " uses a gate with invalid index " + first + " or " + second);
                 }
                 if (first == second + 1) {
                     firstGates.add(gate);
                 } else {
-                    if (first == second) throw new RuntimeException ("Wrong gate, first == second for "+gate);
+                    if (first == second) {
+                        throw new RuntimeException("Wrong gate, first == second for " + gate);
+                    }
                     if (first > second) {
                         PermutationGate pg = new PermutationGate(first - 1, second, nqubit);
                         Step prePermutation = new Step(pg);
@@ -162,7 +172,7 @@ public class Computations {
                         postPermutation.setComplexStep(s.getIndex());
                         s.setComplexStep(-1);
                     } else {
-                        PermutationGate pg = new PermutationGate(first, second, nqubit );
+                        PermutationGate pg = new PermutationGate(first, second, nqubit);
                         Step prePermutation = new Step(pg);
                         Step prePermutationInv = new Step(pg);
                         int realStep = s.getIndex();
@@ -171,13 +181,13 @@ public class Computations {
                         answer.add(prePermutationInv);
                         Step postPermutation = new Step();
                         Step postPermutationInv = new Step();
-                        if (first != second -1) {
-                            PermutationGate pg2 = new PermutationGate(second-1, first, nqubit );
+                        if (first != second - 1) {
+                            PermutationGate pg2 = new PermutationGate(second - 1, first, nqubit);
                             postPermutation.addGate(pg2);
                             postPermutationInv.addGate(pg2);
                             answer.add(1, postPermutation);
                             answer.add(3, postPermutationInv);
-                        } 
+                        }
                         prePermutationInv.setComplexStep(realStep);
                     }
                 }
@@ -199,7 +209,7 @@ public class Computations {
                         Step prePermutation = new Step(pg);
                         Step postPermutation = new Step(pg);
                         answer.add(p0idx, prePermutation);
-                        answer.add(answer.size()-p0idx, postPermutation);
+                        answer.add(answer.size() - p0idx, postPermutation);
                         p0idx++;
                         postPermutation.setComplexStep(s.getIndex());
                         s.setComplexStep(-1);
@@ -210,47 +220,46 @@ public class Computations {
                             sThird = first;
                         }
                     }
-                    if (sSecond != sFirst -1) {
+                    if (sSecond != sFirst - 1) {
                         PermutationGate pg = new PermutationGate(sFirst - 1, sSecond, nqubit);
                         Step prePermutation = new Step(pg);
                         Step postPermutation = new Step(pg);
                         answer.add(p0idx, prePermutation);
-                        answer.add(answer.size()-p0idx, postPermutation);
+                        answer.add(answer.size() - p0idx, postPermutation);
                         p0idx++;
                         postPermutation.setComplexStep(s.getIndex());
                         s.setComplexStep(-1);
-                        sSecond = sFirst -1;
+                        sSecond = sFirst - 1;
                     }
-                    if (sThird != sFirst -2) {
+                    if (sThird != sFirst - 2) {
                         PermutationGate pg = new PermutationGate(sFirst - 2, sThird, nqubit);
                         Step prePermutation = new Step(pg);
                         Step postPermutation = new Step(pg);
                         answer.add(p0idx, prePermutation);
-                        answer.add(answer.size()-p0idx, postPermutation);
+                        answer.add(answer.size() - p0idx, postPermutation);
                         p0idx++;
                         postPermutation.setComplexStep(s.getIndex());
                         s.setComplexStep(-1);
-                        sThird = sFirst -2;
+                        sThird = sFirst - 2;
                     }
                 }
-            }
-            else {
+            } else {
                 throw new RuntimeException("Gate must be SingleQubit or TwoQubit");
             }
         }
         return answer;
     }
-    
+
     public static void printMatrix(Complex[][] a) {
         for (int i = 0; i < a.length; i++) {
             StringBuilder sb = new StringBuilder();
             for (int j = 0; j < a[i].length; j++) {
                 sb.append(a[i][j]).append("    ");
             }
-            System.out.println("m["+i+"]: "+sb);
+            System.out.println("m[" + i + "]: " + sb);
         }
     }
-    
+
     public static int getInverseModulus(int a, int b) {
         int r0 = a;
         int r1 = b;
@@ -259,20 +268,20 @@ public class Computations {
         int s1 = 0;
         int s2 = 0;
         while (r1 != 1) {
-            int q = r0/r1;
-            r2 = r0%r1;
-            s2 = s0 - q*s1;
+            int q = r0 / r1;
+            r2 = r0 % r1;
+            s2 = s0 - q * s1;
             r0 = r1;
             r1 = r2;
             s0 = s1;
             s1 = s2;
         }
-        return s1 > 0 ? s1 : s1+b;
+        return s1 > 0 ? s1 : s1 + b;
     }
-    
-    public static int gcd (int a, int b) {
+
+    public static int gcd(int a, int b) {
         int x = a > b ? a : b;
-        int y = x==a ? b :a ;
+        int y = x == a ? b : a;
         int z = 0;
         while (y != 0) {
             z = x % y;
@@ -281,40 +290,41 @@ public class Computations {
         }
         return x;
     }
-    
-    public static int fraction (int p, int max) {
+
+    public static int fraction(int p, int max) {
         int length = (int) Math.ceil(Math.log(max) / Math.log(2));
         int offset = length;
-        int dim = 1 <<offset;
-        double r = (double)p/dim+.000001;
+        int dim = 1 << offset;
+        double r = (double) p / dim + .000001;
         int period = Computations.fraction(r, max);
         return period;
     }
-        
-        
-    public static int fraction (double d, int max) {
+
+    public static int fraction(double d, int max) {
         double EPS = 1e-15;
         int answer = -1;
-        int h = 0; int k = -1;
-        int a = (int)d;
+        int h = 0;
+        int k = -1;
+        int a = (int) d;
         double r = d - a;
         int h_2 = 0;
         int h_1 = 1;
         int k_2 = 1;
         int k_1 = 0;
-        while ((k < max) && (r > EPS )){
-            h = a*h_1+h_2;
-            k = a*k_1+k_2;
-            h_2 = h_1; h_1 = h;
-            k_2 = k_1; k_1 = k;
-            double rec = 1/r;
-            a = (int)rec;
+        while ((k < max) && (r > EPS)) {
+            h = a * h_1 + h_2;
+            k = a * k_1 + k_2;
+            h_2 = h_1;
+            h_1 = h;
+            k_2 = k_1;
+            k_1 = k;
+            double rec = 1 / r;
+            a = (int) rec;
             r = rec - a;
         }
         return k_2;
     }
-    
-    
+
     public static Complex[][] createIdentity(int dim) {
         Complex[][] matrix = new Complex[dim][dim];
         for (int i = 0; i < dim; i++) {
@@ -326,14 +336,16 @@ public class Computations {
     }
 
     public static void printMemory() {
-        if (!debug) return;
+        if (!debug) {
+            return;
+        }
         Runtime rt = Runtime.getRuntime();
-        long fm = rt.freeMemory()/1024;
-        long mm = rt.maxMemory()/1024;
-        long tm = rt.totalMemory()/1024;
+        long fm = rt.freeMemory() / 1024;
+        long mm = rt.maxMemory() / 1024;
+        long tm = rt.totalMemory() / 1024;
         long um = tm - fm;
-        System.err.println("free = "+fm+", mm = "+mm+", tm = "+tm+", used = "+um);
-/*
+        System.err.println("free = " + fm + ", mm = " + mm + ", tm = " + tm + ", used = " + um);
+        /*
         System.err.println("now gc...");
         System.gc();
         fm = rt.freeMemory()/1024;
@@ -341,101 +353,146 @@ public class Computations {
         tm = rt.totalMemory()/1024;
         um = tm - fm;
         System.err.println("free = "+fm+", mm = "+mm+", tm = "+tm+", used = "+um);
-*/
+         */
     }
 
-    
-    
-    static Complex[] permutateVector(Complex[] vector, int a, int b) {
+    public static Complex[] permutateVector(Complex[] vector, int a, int b) {
         int amask = 1 << a;
         int bmask = 1 << b;
         int dim = vector.length;
         Complex[] answer = new Complex[dim];
         for (int i = 0; i < dim; i++) {
             int j = i;
-            int x = (amask & i) /amask;
-            int y = (bmask & i) /bmask;
+            int x = (amask & i) / amask;
+            int y = (bmask & i) / bmask;
             if (x != y) {
-               j ^= amask;
-               j ^= bmask;
+                j ^= amask;
+                j ^= bmask;
             }
             answer[i] = vector[j];
         }
         return answer;
     }
 
-    static Complex[] calculateNewState(List<Gate> gates, Complex[] vector, int length) {
-        return getNextProbability(getAllGates(gates, length), vector);
+    public static Complex[] calculateNewState(List<Gate> gates, Complex[] vector, int length) {
+        Complex[] answer = getNextProbability(getAllGates(gates, length), vector);
+        return answer;
     }
-    
     private static Complex[] getNextProbability(List<Gate> gates, Complex[] v) {
-         Gate gate = gates.get(0);
-
-        Complex[][] matrix = gate.getMatrix();
+        Gate gate = gates.get(0);
+        int nqubits = gate.getSize();
+        int gatedim = 1 << nqubits;
         int size = v.length;
-
+        dbg("GETNEXTPROBABILITY asked for size = " + size + " and gates = " + gates);
         if (gates.size() > 1) {
-            List<Gate> nextGates = gates.subList(1, gates.size());
-            int gatedim = matrix.length;
-            int partdim = size/gatedim;
+
+            int partdim = size / gatedim;
             Complex[] answer = new Complex[size];
+            List<Gate> nextGates = gates.subList(1, gates.size());
+            boolean id = true;
+            for (Gate g : nextGates) {
+                id = id && (g instanceof Identity);
+            }
+            if (id) {
+                dbg("ONLY IDENTITY!! partdim = "+partdim);
+                long s0 = System.currentTimeMillis();
+                long s1 = s0;
+                for (int j = 0; j < partdim; j++) {
+                    dbg("do part "+j+" from "+partdim);
+                    Complex[] oldv = new Complex[gatedim];
+                    Complex[] newv = new Complex[gatedim];
+                    for (int i = 0; i < gatedim; i++) {
+                        oldv[i] = v[i * partdim + j];
+                        newv[i] = Complex.ZERO;
+                    }
+
+                    if (gate.hasOptimization()) {
+                        dbg("OPTPART!");
+                        newv = gate.applyOptimize(oldv);
+                    } else {
+                        dbg("GET MATRIX for  "+gate);
+                        Complex[][] matrix = gate.getMatrix();
+                        s1 = System.currentTimeMillis();
+                        for (int i = 0; i < gatedim; i++) {
+                            for (int k = 0; k < gatedim; k++) {
+                                newv[i] = newv[i].add(matrix[i][k].mul(oldv[k]));
+                            }
+                        }
+                    }
+                    for (int i = 0; i < gatedim; i++) {
+                        answer[i * partdim + j] = newv[i];
+                    }
+                    dbg("done part");
+                }
+                long s2 = System.currentTimeMillis();
+                return answer;
+            }
+            long sm0 = System.currentTimeMillis();
             Complex[][] vsub = new Complex[gatedim][partdim];
             for (int i = 0; i < gatedim; i++) {
                 Complex[] vorig = new Complex[partdim];
                 for (int j = 0; j < partdim; j++) {
-                    vorig[j] = v[j + i *partdim];
+                    vorig[j] = v[j + i * partdim];
                 }
                 vsub[i] = getNextProbability(nextGates, vorig);
             }
-
+            long s0 = System.currentTimeMillis();
+            Complex[][] matrix = gate.getMatrix();
+            long s1 = System.currentTimeMillis();
             for (int i = 0; i < gatedim; i++) {
                 for (int j = 0; j < partdim; j++) {
                     answer[j + i * partdim] = Complex.ZERO;
-                    for (int k = 0; k < gatedim;k++) {
+                    for (int k = 0; k < gatedim; k++) {
                         answer[j + i * partdim] = answer[j + i * partdim].add(matrix[i][k].mul(vsub[k][j]));
                     }
                 }
             }
+            long s2 = System.currentTimeMillis();
             return answer;
         } else {
-            if (matrix.length != size) {
-                System.err.println("problem with matrix for gate "+gate);
-                throw new IllegalArgumentException ("wrong matrix size "+matrix.length+" vs vector size "+v.length);
+            if (gatedim != size) {
+                System.err.println("problem with matrix for gate " + gate);
+                throw new IllegalArgumentException("wrong matrix size " + gatedim + " vs vector size " + v.length);
             }
-            Complex[] answer = new Complex[size];
-            for (int i = 0; i < size; i++) {
-                answer[i] = Complex.ZERO;
-                for (int j = 0; j < size; j++) {
-                    answer[i] = answer[i].add(matrix[i][j].mul(v[j]));
+            if (gate.hasOptimization()) {
+                return gate.applyOptimize(v);
+            } else {
+                Complex[][] matrix = gate.getMatrix();
+                Complex[] answer = new Complex[size];
+                for (int i = 0; i < size; i++) {
+                    answer[i] = Complex.ZERO;
+                    for (int j = 0; j < size; j++) {
+                        answer[i] = answer[i].add(matrix[i][j].mul(v[j]));
+                    }
                 }
+                return answer;
             }
-            return answer;
         }
     }
-            
+
     private static List<Gate> getAllGates(List<Gate> gates, int nQubits) {
-        dbg("getAllGates, orig = "+gates);
+        dbg("getAllGates, orig = " + gates);
         List<Gate> answer = new ArrayList<>();
-        int idx = nQubits -1;
-          while (idx >= 0) {
+        int idx = nQubits - 1;
+        while (idx >= 0) {
             final int cnt = idx;
             Gate myGate = gates.stream()
                     .filter(
-                        gate -> gate.getHighestAffectedQubitIndex() == cnt )
+                            gate -> gate.getHighestAffectedQubitIndex() == cnt)
                     .findFirst()
                     .orElse(new Identity(idx));
-            dbg("stepmatrix, cnt = "+cnt+", idx = "+idx+", myGate = "+myGate);
-                           answer.add(myGate);    
-           if (myGate instanceof BlockGate) {
-                BlockGate sqg = (BlockGate)myGate;
-                idx = idx - sqg.getSize()+1;
-                dbg("processed blockgate, size = "+sqg.getSize()+", idx = "+idx);
-            }           
+            dbg("stepmatrix, cnt = " + cnt + ", idx = " + idx + ", myGate = " + myGate);
+            answer.add(myGate);
+            if (myGate instanceof BlockGate) {
+                BlockGate sqg = (BlockGate) myGate;
+                idx = idx - sqg.getSize() + 1;
+                dbg("processed blockgate, size = " + sqg.getSize() + ", idx = " + idx);
+            }
             if (myGate instanceof TwoQubitGate) {
                 idx--;
             }
             if (myGate instanceof ThreeQubitGate) {
-                idx = idx-2;
+                idx = idx - 2;
             }
             if (myGate instanceof PermutationGate) {
                 throw new RuntimeException("No perm allowed ");
@@ -468,7 +525,7 @@ public class Computations {
             if (gap > bs) {
                 high = control;
                 size = high - low + 1;
-                PermutationGate pg = new PermutationGate(control , control  - gap + bs,low + size);
+                PermutationGate pg = new PermutationGate(control, control - gap + bs, low + size);
 
                 perm.add(pg);
             }
@@ -476,19 +533,19 @@ public class Computations {
             low = control;
             high = idx + bs - 1;
             size = high - low + 1;
-         //   gate.correctHigh(low+bs);
+            //   gate.correctHigh(low+bs);
             for (int i = low; i < low + size - 1; i++) {
                 PermutationGate pg = new PermutationGate(i, i + 1, low + size);
                 perm.add(0, pg);
             }
         }
-     //   answer.add(new Step(gate));
-      //  dbg("processing cbg, will need to add those perms: "+perm);
-        for (PermutationGate pg :  perm) {
+
+        for (PermutationGate pg : perm) {
             Step lpg = new Step(pg);
             lpg.setComplexStep(1);
             answer.add(lpg);
             answer.add(0, new Step(pg));
         }
     }
+
 }

--- a/src/test/java/org/redfx/strange/test/ArithmeticTests.java
+++ b/src/test/java/org/redfx/strange/test/ArithmeticTests.java
@@ -165,6 +165,20 @@ public class ArithmeticTests extends BaseGateTests {
     }
     
     @Test
+    public void addmodp0() {
+        int N = 1;
+        int dim = 2;
+        Program p = new Program(dim);
+        AddInteger min = new AddInteger(0,1,N).inverse();
+        p.addStep(new Step(min));
+        Result result = runProgram(p);
+        Qubit[] q = result.getQubits();
+        assertEquals(2, q.length);
+        assertEquals(1, q[0].measure());
+        assertEquals(1, q[1].measure());
+    }
+    
+    @Test
     public void add0num0() {
         Program p = new Program(1);
         Step prep = new Step();
@@ -431,10 +445,6 @@ public class ArithmeticTests extends BaseGateTests {
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
         assertEquals(4, q.length);
-        System.err.println("results: ");
-        for (int i = 0; i < 4; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(0, q[0].measure());
         assertEquals(0, q[1].measure());
         assertEquals(1, q[2].measure());
@@ -453,10 +463,6 @@ public class ArithmeticTests extends BaseGateTests {
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
         assertEquals(6, q.length);
-        System.err.println("results: ");
-        for (int i = 0; i < 6; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(0, q[0].measure());
         assertEquals(0, q[1].measure());
         assertEquals(0, q[2].measure());
@@ -472,7 +478,6 @@ public class ArithmeticTests extends BaseGateTests {
         Add add = new Add(0,0,1,1);
         ControlledBlockGate cbg = new ControlledBlockGate(add, 1,0);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
         Step prep = new Step();
         prep.addGates(new X(0));
         p.addStep(prep);
@@ -493,7 +498,6 @@ public class ArithmeticTests extends BaseGateTests {
         Add add = new Add(0,0,1,1);
         ControlledBlockGate cbg = new ControlledBlockGate(add, 0,2);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
         Step prep = new Step();
         prep.addGates(new X(2));
         p.addStep(prep);
@@ -514,7 +518,6 @@ public class ArithmeticTests extends BaseGateTests {
         Add add = new Add(0,0,1,1);
         ControlledBlockGate cbg = new ControlledBlockGate(add, 1,0);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
         Step prep = new Step();
         prep.addGates(new X(0), new X(2));
         p.addStep(prep);
@@ -535,7 +538,6 @@ public class ArithmeticTests extends BaseGateTests {
         Add add = new Add(0,0,1,1);
         ControlledBlockGate cbg = new ControlledBlockGate(add, 0,2);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
         Step prep = new Step();
         prep.addGates(new X(1), new X(2));
         p.addStep(prep);
@@ -556,7 +558,6 @@ public class ArithmeticTests extends BaseGateTests {
         Add add = new Add(0,0,1,1);
         ControlledBlockGate cbg = new ControlledBlockGate(add, 0,2);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
         Step prep = new Step();
         prep.addGates(new X(0), new X(1), new X(2));
         p.addStep(prep);
@@ -594,10 +595,6 @@ public class ArithmeticTests extends BaseGateTests {
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
         assertEquals(6, q.length);
-        System.err.println("results: ");
-        for (int i = 0; i < 6; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(0, q[0].measure());
         assertEquals(0, q[1].measure());
         assertEquals(0, q[2].measure());
@@ -997,10 +994,6 @@ public class ArithmeticTests extends BaseGateTests {
 
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-                System.err.println("Results: ");
-        for (int i = 0; i < 7; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(7, q.length);
         assertEquals(1, q[0].measure());
         assertEquals(1, q[1].measure());
@@ -1025,10 +1018,6 @@ public class ArithmeticTests extends BaseGateTests {
         p.addStep(mod);
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        System.err.println("Results: ");
-        for (int i = 0; i < 7; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(7, q.length);
         assertEquals(1, q[0].measure());
         assertEquals(0, q[1].measure());
@@ -1084,17 +1073,12 @@ public class ArithmeticTests extends BaseGateTests {
         p.addStep(new Step( new Swap(3,7)));
 
         int invsteps = Computations.getInverseModulus(mul,N);
-        System.err.println("INVSTEPS = "+invsteps);
         for (int i = 0; i < invsteps; i++) {
             AddModulus addModulus = new AddModulus(0, 3, 4, 7, N).inverse();
             p.addStep(new Step(addModulus));
         }
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        System.err.println("Results: ");
-        for (int i = 0; i < 9; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(9, q.length);
         assertEquals(0, q[0].measure()); // q2,q1,q0,q3 should be clean
         assertEquals(0, q[1].measure());  
@@ -1119,10 +1103,7 @@ public class ArithmeticTests extends BaseGateTests {
         p.addStep(s);
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        System.err.println("results: ");
-        for (int i = 0; i < 9; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
+
         assertEquals(9, q.length);
         assertEquals(0, q[0].measure()); // q2,q1,q0,q3 should be clean
         assertEquals(0, q[1].measure());  
@@ -1147,10 +1128,6 @@ public class ArithmeticTests extends BaseGateTests {
         p.addStep(s);
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        System.err.println("results: ");
-        for (int i = 0; i < 9; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(10, q.length);
         assertEquals(0, q[0].measure());
         assertEquals(0, q[1].measure()); // q2,q1,q0,q3 should be clean
@@ -1176,10 +1153,6 @@ public class ArithmeticTests extends BaseGateTests {
         p.addStep(s);
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        System.err.println("results: ");
-        for (int i = 0; i < 9; i++) {
-            System.err.println("m["+i+"]: "+q[i].measure());
-        }
         assertEquals(9, q.length);
         assertEquals(0, q[0].measure()); // q2,q1,q0,q3 should be clean
         assertEquals(0, q[1].measure());  

--- a/src/test/java/org/redfx/strange/test/BlockTests.java
+++ b/src/test/java/org/redfx/strange/test/BlockTests.java
@@ -32,21 +32,26 @@
  */
 package org.redfx.strange.test;
 
-
-
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import org.redfx.strange.Block;
 import org.redfx.strange.BlockGate;
+import org.redfx.strange.Complex;
+import org.redfx.strange.ControlledBlockGate;
 import org.redfx.strange.Gate;
 import org.redfx.strange.Program;
 import org.redfx.strange.Qubit;
 import org.redfx.strange.Result;
 import org.redfx.strange.Step;
+import org.redfx.strange.gate.AddInteger;
 import org.redfx.strange.gate.Cnot;
+import org.redfx.strange.gate.Fourier;
+import org.redfx.strange.gate.Hadamard;
+import org.redfx.strange.gate.R;
 import org.redfx.strange.gate.Toffoli;
 import org.redfx.strange.gate.X;
-
 
 /**
  *
@@ -54,7 +59,7 @@ import org.redfx.strange.gate.X;
  */
 public class BlockTests extends BaseGateTests {
 
-   @Test
+    @Test
     public void empty() {
     }
 
@@ -77,7 +82,6 @@ public class BlockTests extends BaseGateTests {
 //                () -> block.addGate(Gate.cnot(2, 1)));
 //        block.addGate(Gate.x(1));
 //    }
-
     @Test
     public void createBlockInProgram() {
         Block block = new Block(1);
@@ -89,8 +93,8 @@ public class BlockTests extends BaseGateTests {
         Qubit[] qubits = result.getQubits();
         assertEquals(0, qubits[0].measure());
     }
-    
-   @Test
+
+    @Test
     public void createXBlockInProgram() {
         Block block = new Block(1);
         Step bs = new Step(Gate.x(0));
@@ -102,7 +106,7 @@ public class BlockTests extends BaseGateTests {
         Qubit[] qubits = result.getQubits();
         assertEquals(1, qubits[0].measure());
     }
-        
+
     @Test
     public void createXBlockInProgramAddPos2() {
         Block block = new Block(1);
@@ -143,7 +147,7 @@ public class BlockTests extends BaseGateTests {
         Qubit[] qubits = result.getQubits();
         assertEquals(0, qubits[0].measure());
     }
-    
+
     @Test
     public void createXXBlockInProgramAddPos2() {
         Block block = new Block(1);
@@ -157,7 +161,7 @@ public class BlockTests extends BaseGateTests {
         assertEquals(0, qubits[1].measure());
         assertEquals(0, qubits[0].measure());
     }
-    
+
     @Test
     public void compareBlock() {
         for (int a = 0; a < 4; a++) {
@@ -182,7 +186,6 @@ public class BlockTests extends BaseGateTests {
                 p.addSteps(prep, s0, s1, s2);
                 Result normal = runProgram(p);
                 Qubit[] normalQ = normal.getQubits();
-                System.err.println("CREATE BLOCK NOW");
                 Block carry = new Block("carry", 4);
                 carry.addStep(new Step(new Toffoli(1, 2, 3)));
                 carry.addStep(new Step(new Cnot(1, 2)));
@@ -215,36 +218,244 @@ public class BlockTests extends BaseGateTests {
                 }
 
                 Program p = new Program(4);
-             
+
                 Step s0 = new Step(new Toffoli(1,2,3));
                 Step s1 = new Step(new Cnot(1, 2));
                 p.addSteps(prep, s0, s1);
                 Result normal = runProgram(p);
                 Qubit[] normalQ = normal.getQubits();
-                System.err.println("q0 = "+normalQ[0].measure());
-                System.err.println("q1 = "+normalQ[1].measure());
-                System.err.println("q2 = "+normalQ[2].measure());
-                
-                System.err.println("\nCREATE BLOCK NOW");
+
                 Block carry = new Block("carry", 4);
                 carry.addStep(new Step(new Toffoli(1,2,3)));
                 carry.addStep(new Step(new Cnot(1, 2)));
-
 
                 Program bp = new Program(4);
                 Step bs0 = new Step(new BlockGate(carry, 0));
                 bp.addSteps(prep, bs0);
                 Result blockResult = runProgram(bp);
                 Qubit[] blockQ = blockResult.getQubits();
-                System.err.println("qq0 = "+blockQ[0].measure());
-                System.err.println("qq1 = "+blockQ[1].measure());
-                System.err.println("qq2 = "+blockQ[2].measure());
 
                 assertEquals(normalQ.length, blockQ.length);
                 for (int i = 0; i < normalQ.length; i++) {
                     assertEquals(normalQ[i].measure(), blockQ[i].measure());
                 }
             }
+        }
+    }
+
+    @Test
+    public void testDummyBlockGate() {
+        DummyBlockGate dbg = new DummyBlockGate(0);
+        Program bp = new Program(2);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(1, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+    }
+
+    @Test
+    public void testDummyBlockGate2() {
+        DummyBlockGate dbg = new DummyBlockGate(1);
+        Program bp = new Program(3);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+        assertEquals(1, qubits[2].measure());
+    }
+    
+    @Test
+    public void testDummyBlockGateInv() {
+        DummyBlockGate dbg = new DummyBlockGate(0).inverse();
+        Program bp = new Program(2);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+    }
+    
+    @Test
+    public void testDummyBlockGateInv2() {
+        DummyBlockGate dbg = new DummyBlockGate(1).inverse();
+        Program bp = new Program(3);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(0, qubits[1].measure());
+        assertEquals(1, qubits[2].measure());
+    }
+        
+    @Test
+    public void testDummyBlockGateR() {
+        DummyBlockGate dbg = new DummyBlockGate(0, new Step(new R(2,0)));
+        Program bp = new Program(2);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(1, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+    }
+    
+    @Test
+    public void testDummyBlockGateR2() {
+        DummyBlockGate dbg = new DummyBlockGate(1, new Step(new R(2,0)));
+        Program bp = new Program(3);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+        assertEquals(1, qubits[2].measure());
+    }
+                       
+    @Test
+    public void testDummyBlockGateRinv() {
+        DummyBlockGate dbg = new DummyBlockGate(0, new Step(new R(2,0))).inverse();
+        Program bp = new Program(2);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+    }
+    
+    @Test
+    public void testDummyBlockGateRinv2() {
+        DummyBlockGate dbg = new DummyBlockGate(1, new Step(new R(2,0))).inverse();
+        Program bp = new Program(3);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        assertEquals(0, qubits[0].measure());
+        assertEquals(0, qubits[1].measure());
+        assertEquals(1, qubits[2].measure());
+    }
+    
+    @Test
+    public void testGenericBlockGateHHF() {
+        Step prep = new Step(new X(0));
+        List<Step> steps = new ArrayList<>();
+        steps.add(new Step(new Hadamard(0), new Hadamard(1)));
+        steps.add(new Step(new Fourier(2,0)));
+        GenericBlockGate dbg = new GenericBlockGate(0, 2, steps).inverse();
+        Program bp = new Program(2);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(prep, bs0);
+        Result result = runProgram(bp);
+        Complex[] probability = result.getProbability();
+        float EPS = (float)1e-4;
+        assertEquals(0, probability[0].r, EPS);
+        assertEquals(0, probability[0].i, EPS);
+        assertEquals(0, probability[1].r, EPS);
+        assertEquals(0, probability[1].i, EPS);
+        assertEquals(0.5, probability[2].r, EPS);
+        assertEquals(-0.5, probability[2].i, EPS);
+        assertEquals(0.5, probability[3].r, EPS);
+        assertEquals(0.5, probability[3].i, EPS);
+    
+    }
+    
+    @Test
+    public void testGenericBlockGateAMF() {
+        List<Step> steps = new ArrayList<>();
+        Step prep = new Step(new X(2));
+        int x0 = 0; int x1 = 1; int N = 1; int dim = 3; int y0 = 2; int y1 = 3;
+        
+        AddInteger addN = new AddInteger(x0,x1,N);
+        ControlledBlockGate cbg = new ControlledBlockGate(addN, x0,2);
+        steps.add(new Step(cbg));
+
+        GenericBlockGate dbg = new GenericBlockGate(0, dim, steps).inverse();
+        Program bp = new Program(3);
+        Step bs0 = new Step(dbg);
+        bp.addSteps(prep, bs0);
+        Result result = runProgram(bp);
+        Qubit[] qubits = result.getQubits();
+        for (int i = 0; i < dim; i++) {
+         //   System.err.println("m["+i+"]: "+qubits[i].measure());
+        }
+        assertEquals(1, qubits[0].measure());
+        assertEquals(1, qubits[1].measure());
+        assertEquals(1, qubits[2].measure());
+    }
+            
+    class DummyBlockGate extends BlockGate<DummyBlockGate> {
+
+        Block block;
+        Step addedStep = null;
+
+        public DummyBlockGate(int idx) {
+            this (idx, null);
+        }
+        
+        public DummyBlockGate(int idx, Step s) {
+            super();
+            setIndex(idx);
+            this.block = createBlock();
+            this.addedStep = s;
+            setBlock(block);
+        }
+
+        public Block createBlock() {
+            Block answer = new Block("Dummy", 2);
+            answer.addStep(new Step(new X(1)));
+            if (this.addedStep != null) {
+                answer.addStep(addedStep);
+            }
+            answer.addStep(new Step(new Cnot(1, 0)));
+            return answer;
+        }
+
+        @Override
+        public boolean hasOptimization() {
+            return true;
+            // return !inverse;
+        }
+    }
+    
+    
+    class GenericBlockGate extends BlockGate<GenericBlockGate> {
+
+        Block block;
+        List<Step> steps = null;
+        private int dim;
+
+        public GenericBlockGate(int idx, int dim) {
+            this (idx, dim, null);
+        }
+        
+        public GenericBlockGate(int idx, int dim, List<Step> s) {
+            super();
+            setIndex(idx);
+            this.steps = s;
+            this.dim = dim;
+            this.block = createBlock();
+            setBlock(block);
+        }
+
+        public Block createBlock() {
+            Block answer = new Block("Generic", dim);
+            for (Step step : steps) {
+                answer.addStep(step);
+            }
+            return answer;
+        }
+
+        @Override
+        public boolean hasOptimization() {
+            return true;
         }
     }
 }

--- a/src/test/java/org/redfx/strange/test/ClassicTests.java
+++ b/src/test/java/org/redfx/strange/test/ClassicTests.java
@@ -47,7 +47,6 @@ public class ClassicTests {
         int o = 0;
         for (int i = 0; i < 100; i++) {
             int b = Classic.randomBit();
-            System.out.println("b = "+b);
             if (b == 0) z++;
             if (b == 1) o++;
         }

--- a/src/test/java/org/redfx/strange/test/ControlledBlockTests.java
+++ b/src/test/java/org/redfx/strange/test/ControlledBlockTests.java
@@ -78,7 +78,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 0, 1);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -102,7 +101,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 1, 0);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -122,7 +120,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 1, 2);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -143,7 +140,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 0, 2);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -164,15 +160,11 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 1, 0);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
         Result result = runProgram(p);
         Qubit[] q = result.getQubits();
-        for (int i = 0; i < 3; i++) {
-            System.err.println("q["+i+"] = "+q[i].measure());
-        }
         assertEquals(3, q.length);
         assertEquals(1, q[0].measure());
         assertEquals(1, q[1].measure());
@@ -189,7 +181,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 2, 0);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -197,9 +188,6 @@ public class ControlledBlockTests extends BaseGateTests {
         Complex[] probability = result.getProbability();
         Complex.printArray(probability);
         Qubit[] q = result.getQubits();
-                for (int i = 0; i < 3; i++) {
-            System.err.println("q["+i+"] = "+q[i].measure());
-        }
         assertEquals(3, q.length);
         assertEquals(1, q[0].measure());
         assertEquals(0, q[1].measure());
@@ -215,7 +203,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 3, 1);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -223,9 +210,6 @@ public class ControlledBlockTests extends BaseGateTests {
         Complex[] probability = result.getProbability();
         Complex.printArray(probability);
         Qubit[] q = result.getQubits();
-                for (int i = 0; i < 4; i++) {
-            System.err.println("q["+i+"] = "+q[i].measure());
-        }
         assertEquals(4, q.length);
         assertEquals(0, q[0].measure());
         assertEquals(1, q[1].measure());
@@ -242,7 +226,6 @@ public class ControlledBlockTests extends BaseGateTests {
         BlockGate gate = new BlockGate(block, 0);
         ControlledBlockGate cbg = new ControlledBlockGate(gate, 1, 3);
         Complex[][] m = cbg.getMatrix();
-        Complex.printMatrix(m, System.err);
 
         p.addStep(prep);
         p.addStep(new Step(cbg));
@@ -250,9 +233,7 @@ public class ControlledBlockTests extends BaseGateTests {
         Complex[] probability = result.getProbability();
         Complex.printArray(probability);
         Qubit[] q = result.getQubits();
-                for (int i = 0; i < 4; i++) {
-            System.err.println("q["+i+"] = "+q[i].measure());
-        }
+
         assertEquals(4, q.length);
         assertEquals(0, q[0].measure());
         assertEquals(0, q[1].measure());

--- a/src/test/java/org/redfx/strange/test/ThreeQubitGateTests.java
+++ b/src/test/java/org/redfx/strange/test/ThreeQubitGateTests.java
@@ -182,7 +182,6 @@ public class ThreeQubitGateTests extends BaseGateTests {
 
     @Test
     public void ToffoliGateR4() {
-        System.err.println("R4");
         // |1100> -> |1101>
         Program p = new Program(4,
            new Step(new X(2),new X(3)),
@@ -198,7 +197,6 @@ public class ThreeQubitGateTests extends BaseGateTests {
 
     @Test
     public void ToffoliGateS2() {
-        System.err.println("S2");
         // |0101> -> |1101>
         Program p = new Program(4,
            new Step(new X(0),new X(2)),


### PR DESCRIPTION
improve performance by using tensor multiplication of gates applied to qubits instead

of using matrix multiplication.
Fix for #75