### PR TITLE
Revert inverse of gates in a step

### DIFF
--- a/src/main/java/org/redfx/strange/Block.java
+++ b/src/main/java/org/redfx/strange/Block.java
@@ -125,8 +125,6 @@ public class Block {
     }
 
     public Complex[] applyOptimize(Complex[] probs, boolean inverse) {
-        int dim = probs.length;
-
         List<Step> simpleSteps = new ArrayList<>();
         for (Step step : steps) {
             simpleSteps.addAll(Computations.decomposeStep(step, nqubits));
@@ -140,6 +138,11 @@ public class Block {
         for (Step step : simpleSteps) {
             if (!step.getGates().isEmpty()) {
                 probs = applyStep(step, probs);
+            }
+        }
+        if (inverse) {
+            for (Step step : simpleSteps) {
+                step.setInverse(true);
             }
         }
         return probs;

--- a/src/test/java/org/redfx/strange/test/Arithmetic4Tests.java
+++ b/src/test/java/org/redfx/strange/test/Arithmetic4Tests.java
@@ -1,0 +1,547 @@
+/*-
+ * #%L
+ * Strange
+ * %%
+ * Copyright (C) 2020 Johan Vos
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Johan Vos nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.redfx.strange.test;
+
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.redfx.strange.Complex;
+import org.redfx.strange.ControlledBlockGate;
+import org.redfx.strange.Program;
+import org.redfx.strange.QuantumExecutionEnvironment;
+import org.redfx.strange.Qubit;
+import org.redfx.strange.Result;
+import org.redfx.strange.Step;
+//import org.redfx.strange.gate.AddIntegerModulus;
+import org.redfx.strange.gate.AddModulus;
+import org.redfx.strange.gate.Hadamard;
+import org.redfx.strange.gate.InvFourier;
+import org.redfx.strange.gate.MulModulus;
+import org.redfx.strange.gate.X;
+import org.redfx.strange.local.SimpleQuantumExecutionEnvironment;
+
+
+/**
+ *
+ * @author johan
+ */
+public class Arithmetic4Tests extends BaseGateTests {
+
+    static final double D = 0.000000001d;
+
+   // @Test
+//    public void addmodgate() {
+//        int a = 3;
+//        int n = 3;
+//        int mod = 4;
+//        int dim = n + 2;
+//        Program p = new Program(dim);
+//        Step prep = new Step();
+//        prep.addGates(new X(1));
+//        p.addStep(prep);
+//        
+//        Step modstep = new Step(new AddIntegerModulus(0,3,a, mod));
+//        p.addStep(modstep);
+//        Result result = runProgram(p);
+//        Qubit[] q = result.getQubits();
+//        for (int i = 0; i < q.length; i++) {
+//            System.err.println("Qubit["+i+"] = "+q[i].measure());
+//        }
+//        assertEquals(dim, q.length);
+//        assertEquals(1, q[0].measure());
+//        assertEquals(0, q[1].measure());
+//        assertEquals(0, q[2].measure());
+//        assertEquals(0, q[3].measure());
+//        assertEquals(0, q[4].measure());
+//    }
+//    
+    
+    @Test
+    public void testexpmodHHHHnoinv() {
+        // 0 H H H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        for (int i = 0; i < offset; i++) {
+            prep.addGate(new Hadamard(i));
+        }
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+       // for (int i = length - 1; i > length - 1 - offset; i--) {
+        for (int i = length - 1; i > length - 2; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            if (probs[i].abssqr() > 0.000001) 
+            System.err.println("prob["+i+"]  = "+probs[i]);
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            assertEquals(amps[i], 1./16, 0.001);
+        }
+        Qubit[] qubits = result.getQubits();
+        for (int i = 0; i < qubits.length; i++) {
+            System.err.println("q["+i+"] = "+qubits[i].getProbability());
+//            System.err.println("q["+i+"] = "+qubits[i].measure());
+        }
+    }
+    
+    
+  //  @Test
+    public void testexpmodHHHH() {
+        // 0 H H H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        for (int i = 0; i < offset; i++) {
+            prep.addGate(new Hadamard(i));
+        }
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = length - 1; i > length - 1 - offset; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            if (i%4 == 0) {
+                assertEquals(amps[i], .25, 0.001);
+            } else {
+                assertEquals(amps[i], 0, 0.001);
+            }
+        }
+    }
+    
+   // @Test
+    public void testexpmod0HHH() {
+        // 0 H H H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        for (int i = 1; i < offset; i++) {
+            prep.addGate(new Hadamard(i));
+        }
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = length - 1; i > length - 1 - offset; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            if (i%4 == 0) {
+                assertEquals(amps[i], .25, 0.001);
+            } else {
+                assertEquals(amps[i], 0, 0.001);
+            }
+        }
+    }
+    
+   // @Test
+    public void testexpmod00HH() {
+        // 0 0 H H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        for (int i = 2; i < offset; i++) {
+            prep.addGate(new Hadamard(i));
+        }
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = length - 1; i > length - 1 - offset; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            if (i%4 == 0) {
+                assertEquals(amps[i], .25, 0.001);
+            } else {
+                assertEquals(amps[i], 0, 0.001);
+            }
+        }
+    }
+    
+    //@Test
+    public void testexpmod1() {
+        // 1 0 0 0 { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        prep.addGates(new X(0));
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = length - 1; i > length - 1 - offset; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            assertEquals(amps[i], 1./16, 0.001);
+        }
+        
+    }
+
+   // @Test
+    public void testexpmodH() {
+        // H 0 0 0 { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+
+        prep.addGate(new Hadamard(0));
+        
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = offset - 1; i > - 1; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            System.err.println("Create MulModulus, i = "+i+", m = "+m+", a = "+a+", MOD = "+mod);
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            assertEquals(amps[i], 1./16, 0.001);
+        }
+    }
+    
+   // @Test
+    public void testexpmod000H() {
+        // 0 0 0 H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length;
+
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+
+        prep.addGate(new Hadamard(3));
+        
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = offset - 1; i > - 1; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            System.err.println("Create MulModulus, i = "+i+", m = "+m+", a = "+a+", MOD = "+mod);
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[16];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%16] = amps[i%16] + probs[i].abssqr();
+        }
+        for (int i = 0; i < 16; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            if (i%2 == 0) {
+                assertEquals(amps[i], .125, 0.001);
+            } else {
+                assertEquals(amps[i], 0, 0.001);
+            }
+        }
+    }
+
+  //  @Test
+    public void testexpmod00H() {
+        // 0 0  H { 1 x 7 ^ A mod 15}
+        int mod = 15;
+        int a = 7;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = length -1 ;
+        int dim0 = 1 << offset;
+        assertEquals(dim0, 8);
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+
+        prep.addGate(new Hadamard(2));
+        
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = offset - 1; i > - 1; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            System.err.println("Create MulModulus, i = "+i+", m = "+m+", a = "+a+", MOD = "+mod);
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[dim0];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%dim0] = amps[i%dim0] + probs[i].abssqr();
+        }
+        for (int i = 0; i < dim0; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            if (i%2 == 0) {
+                assertEquals(amps[i], .25, 0.001);
+            } else {
+                assertEquals(amps[i], 0, 0.001);
+            }
+        }
+    }
+  
+   // @Test
+    public void testexpmodH37() {
+        //  H { 1 x 3 ^ A mod 7}
+        int mod = 7;
+        int a = 3;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = 1 ;
+        int dim0 = 1 << offset;
+        assertEquals(dim0, 2);
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+
+        prep.addGate(new X(3));
+        
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = offset - 1; i > - 1; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            System.err.println("Create MulModulus, i = "+i+", m = "+m+", a = "+a+", MOD = "+mod);
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[dim0];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%dim0] = amps[i%dim0] + probs[i].abssqr();
+        }
+        for (int i = 0; i < dim0; i ++) {
+            System.err.println("AMP["+i+"] = "+amps[i]);
+            assertEquals(amps[i], .5, 0.001);
+        }
+    }
+    
+   // @Test
+    public void testexpmodHH37() {
+        //  H { 1 x 3 ^ A mod 7}
+        int mod = 7;
+        int a = 3;
+        int length = (int) Math.ceil(Math.log(mod) / Math.log(2));
+        int offset = 2 ;
+        int dim0 = 1 << offset;
+        assertEquals(dim0, 4);
+        Program p = new Program(2 * length + 3 + offset);
+        Step prep = new Step();
+        for (int i = 0; i < offset; i++) {
+            prep.addGate(new Hadamard(i));
+        }
+        
+        Step prepAnc = new Step(new X(length + 1 + offset));
+        p.addStep(prep);
+        p.addStep(prepAnc);
+        for (int i = offset - 1; i > - 1; i--) {
+            int m = 1;
+            for (int j = 0; j < 1 << i; j++) {
+                m = m * a % mod;
+            }
+            System.err.println("Create MulModulus, i = "+i+", m = "+m+", a = "+a+", MOD = "+mod);
+            MulModulus mul = new MulModulus(length, 2 * length, m, mod);
+            ControlledBlockGate cbg = new ControlledBlockGate(mul, offset, i);
+            p.addStep(new Step(cbg));
+        }
+        p.addStep(new Step(new InvFourier(offset, 0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        Qubit[] q = result.getQubits();
+        int answer = 0;
+        double[] amps = new double[dim0];
+        for (int i = 0; i < probs.length; i++) {
+            amps[i%dim0] = amps[i%dim0] + probs[i].abssqr();
+        }
+        for (int i = 0; i < dim0; i ++) {
+         //   System.err.println("AMP["+i+"] = "+amps[i]);
+            assertEquals(amps[i], .25, 0.001);
+        }
+    }
+    
+  //  @Test
+    void testMinOffset() {
+        int offset = 2;
+        int n = 2;
+        int dim = 2 * n + offset + 3;
+        int mod = 3;
+        Program p = new Program(dim);
+        Step prep = new Step();
+        for (int i = 0; i <offset; i++) {
+            prep.addGate(new X(i));
+        }
+        prep.addGates(new X(2), new X(5));
+        p.addStep(prep);
+        AddModulus a1 = new AddModulus(offset,n+ offset,n+offset+1, offset+ 2*n+1, mod).inverse();
+        p.addStep(new Step(a1));
+        Result result = runProgram(p);
+        Qubit[] q = result.getQubits();
+        assertEquals(q[0].measure(), 1);
+        assertEquals(q[1].measure(), 1);
+        assertEquals(q[2].measure(), 0);
+        assertEquals(q[3].measure(), 0);
+        assertEquals(q[4].measure(), 0);
+        assertEquals(q[5].measure(), 1);
+        assertEquals(q[6].measure(), 0);
+        assertEquals(q[7].measure(), 0);
+        assertEquals(q[8].measure(), 0);
+    }
+
+}

--- a/src/test/java/org/redfx/strange/test/InverseTests.java
+++ b/src/test/java/org/redfx/strange/test/InverseTests.java
@@ -1,0 +1,443 @@
+/*-
+ * #%L
+ * Strange
+ * %%
+ * Copyright (C) 2021 Johan Vos
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Johan Vos nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.redfx.strange.test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.redfx.strange.Block;
+import org.redfx.strange.BlockGate;
+import org.redfx.strange.Complex;
+import org.redfx.strange.Program;
+import org.redfx.strange.Result;
+import org.redfx.strange.Step;
+import org.redfx.strange.gate.Fourier;
+import org.redfx.strange.gate.X;
+
+
+/**
+ *
+ * @author johan
+ */
+public class InverseTests extends BaseGateTests {
+
+    static final double D = 0.000000001d;
+    
+   /*
+    *          |  1   1   1   1  | 
+    * F = 1/2  |  1   i  -1  -i  |
+    *          |  1  -1   1  -1  |
+    *          |  1  -i  -1   i  |
+    */
+    
+    @Test
+    public void fourier1000() { // 00
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0);
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, .5f,D);
+        assertEquals(probs[2].r, .5f,D);
+        assertEquals(probs[3].r, .5f,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, 0, D);
+    }
+        
+    @Test
+    public void fourier0100() { // 01
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0);
+        p.addStep(new Step(new X(0)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, .5, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, -.5, D);
+    }
+      
+    @Test
+    public void fourier0010() { // 10
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0);
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, -.5f,D);
+        assertEquals(probs[2].r, .5f,D);
+        assertEquals(probs[3].r, -.5f,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, 0, D);
+    }
+    
+    @Test
+    public void fourier0001() { // 11
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0);
+        p.addStep(new Step(new X(0), new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, -.5, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, .5, D);
+    }
+      
+    
+    @Test
+    public void invfourier1000() { // 00
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0).inverse();
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, .5f,D);
+        assertEquals(probs[2].r, .5f,D);
+        assertEquals(probs[3].r, .5f,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, 0, D);
+    }
+
+    @Test
+    public void invfourier0100() { // 01
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0).inverse();
+        p.addStep(new Step(new X(0)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, -.5, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, .5, D);
+    }
+      
+    
+    @Test
+    public void invfourier0010() { // 10
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0).inverse();
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, -.5f,D);
+        assertEquals(probs[2].r, .5f,D);
+        assertEquals(probs[3].r, -.5f,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, 0, D);
+    }
+    
+    @Test
+    public void invfourier0001() { // 11
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0).inverse();
+        p.addStep(new Step(new X(0), new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, .5, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, -.5, D);
+    }
+    
+    @Test
+    public void invinvfourier0100() { // 01
+        Program p = new Program(2);
+        Fourier f = new Fourier(2,0).inverse().inverse();
+        p.addStep(new Step(new X(0)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, .5, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, -.5, D);
+    }
+        
+    @Test
+    public void fourier3qX1() { // 01
+        Program p = new Program(3);
+        Fourier f = new Fourier(2,1);
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, .5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, -.5, D);
+        assertEquals(probs[7].i, 0, D);
+    }  
+            
+    @Test
+    public void fourierinv3qX1() { // 01
+        Program p = new Program(3);
+        Fourier f = new Fourier(2,1).inverse();
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, -.5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, .5, D);
+        assertEquals(probs[7].i, 0, D);
+    }  
+    
+    @Test
+    public void block3Qx1() {
+        Program p = new Program(3);
+        Block block = new Block("myfourier", 2);
+        block.addStep(new Step(new Fourier(2,0)));
+        BlockGate bg = new BlockGate(block, 1);
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(bg));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, .5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, -.5, D);
+        assertEquals(probs[7].i, 0, D);
+    }
+    
+    @Test
+    public void blockinv3qX1() {
+        Program p = new Program(3);
+        Block block = new Block("myfourier", 2);
+        block.addStep(new Step(new Fourier(2,0).inverse()));
+        BlockGate bg = new BlockGate(block, 1);
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(bg));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();   
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, -.5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, .5, D);
+        assertEquals(probs[7].i, 0, D);
+    }
+    
+    @Test
+    public void blockinvgate3qX1() {
+        Program p = new Program(3);
+        Block block = new Block("myfourier", 2);
+        block.addStep(new Step(new Fourier(2,0)));
+        BlockGate bg = (BlockGate) new BlockGate(block, 1).inverse();
+        p.addStep(new Step(new X(1)));
+        p.addStep(new Step(bg));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();  
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, -.5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, .5, D);
+        assertEquals(probs[7].i, 0, D);
+    }
+    
+    
+    @Test
+    public void fourier3qX2() { // 01
+        Program p = new Program(3);
+        Fourier f = new Fourier(2,1);
+        p.addStep(new Step(new X(2)));
+        p.addStep(new Step(f));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, .5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, -.5f,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, 0, D);
+        assertEquals(probs[7].i, 0, D);
+    }  
+    
+    @Test
+    public void fourierinv3qX2() { // 01
+        Program p = new Program(3);
+        Fourier f = new Fourier(2,0);
+        p.addStep(new Step(new X(0), new X(2)));
+        p.addStep(new Step(new X(2), f.inverse()));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, -.5f,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, 0,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, -.5f, D);
+        assertEquals(probs[2].i, 0, D);
+        assertEquals(probs[3].i, .5f, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, 0, D);
+        assertEquals(probs[7].i, 0, D);
+    }  
+    
+    @Test
+    public void blockinvgate3qX2() {
+        Program p = new Program(3);
+        Block block = new Block("myfourier", 2);
+        block.addStep(new Step(new Fourier(2,0)));
+        BlockGate bg = (BlockGate) new BlockGate(block, 1).inverse();
+        p.addStep(new Step(new X(0), new X(1)));
+        p.addStep(new Step(bg));
+        p.addStep(new Step(new X(0)));
+        Result result = runProgram(p);
+        Complex[] probs = result.getProbability();
+        assertEquals(probs[0].r, .5f,D);
+        assertEquals(probs[1].r, 0,D);
+        assertEquals(probs[2].r, 0,D);
+        assertEquals(probs[3].r, 0,D);
+        assertEquals(probs[4].r, -.5f,D);
+        assertEquals(probs[5].r, 0,D);
+        assertEquals(probs[6].r, 0,D);
+        assertEquals(probs[7].r, 0,D);
+        assertEquals(probs[0].i, 0, D);
+        assertEquals(probs[1].i, 0, D);
+        assertEquals(probs[2].i, -.5, D);
+        assertEquals(probs[3].i, 0, D);
+        assertEquals(probs[4].i, 0, D);
+        assertEquals(probs[5].i, 0, D);
+        assertEquals(probs[6].i, .5, D);
+        assertEquals(probs[7].i, 0, D);
+     }
+
+}


### PR DESCRIPTION
When the inverse of a blockgate needs to be used, the steps are inversed.

This inversion needs to be reverted after the calculations, as the same
steps might be used in future computations.