### PR TITLE
Fix #92

### DIFF
--- a/src/main/java/org/redfx/strange/Complex.java
+++ b/src/main/java/org/redfx/strange/Complex.java
@@ -337,11 +337,10 @@ public final class Complex {
         }
     }
 
- 
     @Override
     public String toString() {
-        double mr = this.r;
-        double mi = this.i;
+        float mr = this.r;
+        float mi = this.i;
         if (Math.abs(mr) < 1e-7) mr = 0;
         if (Math.abs(mi) < 1e-7) mi = 0;
         if (Math.abs(mr) > .999999) mr = 1;

--- a/src/test/java/org/redfx/strange/test/ComplexTest.java
+++ b/src/test/java/org/redfx/strange/test/ComplexTest.java
@@ -34,7 +34,7 @@ package org.redfx.strange.test;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import org.redfx.strange.Complex;
 public class ComplexTest {
 
@@ -48,6 +48,14 @@ public class ComplexTest {
         assertTrue(zero.r == 1);
         Complex z2 = new Complex(0.,0.);
         assertTrue(z2.r == 0);
+    }
+
+    @Test
+    public void toStringTest() {
+        Complex neg = new Complex(-.1, -.2);
+        String negString = neg.toString();
+        assertEquals(negString, "(-0.1, -0.2)");
+        System.err.println("NEG = "+negString);
     }
 
 }


### PR DESCRIPTION
Complex uses floats (to save memory) but for toString() were are used.
That caused rounding errors in the toString()