### PR TITLE
Deploy maven artifacts to central portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,16 +140,6 @@
       </plugin>
     </plugins>
   </build>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <profiles>
     <profile>
       <id>release</id>
@@ -190,14 +180,6 @@
               </execution>
             </executions>
           </plugin>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>2.7</version>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
@@ -222,6 +204,17 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+              <groupId>org.sonatype.central</groupId>
+              <artifactId>central-publishing-maven-plugin</artifactId>
+              <version>0.7.0</version>
+              <extensions>true</extensions>
+              <configuration>
+                <publishingServerId>ossrh</publishingServerId>
+                <autoPublish>true</autoPublish>
+                <waitUntil>published</waitUntil>
+              </configuration>
+            </plugin>
         </plugins>
       </build>
     </profile>
@@ -242,7 +235,6 @@
     </developer>
   </developers>
 
-
   <scm>
     <connection>scm:git:git://github.com/redfx-quantum/strange.git</connection>
     <developerConnection>scm:git:git@github.com:redfx-quantum/strange.git</developerConnection>
@@ -251,4 +243,3 @@
   </scm>
 
 </project>
-


### PR DESCRIPTION
Publishing to maven central will soon no longer be possible to the oss.sonatype.org nexus repository. See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more information.

For maven we need to use sonatype's `central-publishing-maven-plugin` for artifact publication. A `distributionManagement` section is no longer required.