### PR TITLE
[DRAFT] 195-namedqubits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 23
           distribution: 'oracle'
           cache: 'maven' 
           server-id: ossrh

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <javadoc.plugin.version>3.10.1</javadoc.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
     </properties>

--- a/src/main/java/org/redfx/strange/Gate.java
+++ b/src/main/java/org/redfx/strange/Gate.java
@@ -199,6 +199,8 @@ public interface Gate {
      */
     public int getMainQubitIndex();
     
+    default Qubit getQubit() {return null;}
+
     /**
      * <p>setAdditionalQubit.</p>
      *

--- a/src/main/java/org/redfx/strange/Gate.java
+++ b/src/main/java/org/redfx/strange/Gate.java
@@ -200,6 +200,8 @@ public interface Gate {
     public int getMainQubitIndex();
     
     default Qubit getQubit() {return null;}
+    default Qubit getSecondQubit() {return null;}
+    default Qubit getThirdQubit() {return null;}
 
     /**
      * <p>setAdditionalQubit.</p>

--- a/src/main/java/org/redfx/strange/Program.java
+++ b/src/main/java/org/redfx/strange/Program.java
@@ -56,6 +56,7 @@ public class Program {
     private Result result;
     private double[] initAlpha;
 
+    private Qubit[] qubits;
     private final ArrayList<Step> steps = new ArrayList<>();
 
     // cache decomposedSteps
@@ -72,9 +73,24 @@ public class Program {
      */
     public Program(int nQubits, Step... moreSteps) {
         this.numberQubits = nQubits;
+        this.qubits = new Qubit[nQubits];
+        for (int i = 0; i < nQubits; i++) {
+            this.qubits[i] = new Qubit();
+        }
         this.initAlpha = new double[numberQubits];
         Arrays.fill(initAlpha, 1d);
         addSteps(moreSteps);
+    }
+
+    public Program(Qubit... qubits) {
+        this.qubits = qubits;
+        this.numberQubits = qubits.length;
+        this.initAlpha = new double[numberQubits];
+        Arrays.fill(initAlpha, 1d);
+    }
+
+    public Qubit[] getQubits() {
+        return this.qubits;
     }
 
     /**
@@ -117,6 +133,23 @@ public class Program {
     public void addStep(Step step) {
         if (!ensureMeasuresafe( Objects.requireNonNull(step)) ) {
             throw new IllegalArgumentException ("Adding a superposition step to a measured qubit");
+        }
+        List<Gate> gates = step.getGates();
+        System.err.println("gates = "+gates);
+        for (Gate gate : gates) {
+            System.err.println("gate = "+gate);
+            Qubit candidate = gate.getQubit();
+            if (candidate != null) {
+                System.err.println("candidate = "+candidate);
+                if (this.qubits != null) {
+                    for (int i = 0; i < this.qubits.length; i++) {
+                        if (candidate.equals(this.qubits[i])) {
+                            System.err.println("this is qubit "+i);
+                            gate.setMainQubitIndex(i);
+                        }
+                    }
+                }
+            }
         }
         step.setIndex(steps.size());
         step.setProgram(this);

--- a/src/main/java/org/redfx/strange/Program.java
+++ b/src/main/java/org/redfx/strange/Program.java
@@ -135,13 +135,12 @@ public class Program {
             throw new IllegalArgumentException ("Adding a superposition step to a measured qubit");
         }
         List<Gate> gates = step.getGates();
-        System.err.println("gates = "+gates);
         for (Gate gate : gates) {
             System.err.println("gate = "+gate);
             Qubit candidate = gate.getQubit();
             if (candidate != null) {
-                getIndexByQubit(candidate);
-                gate.setMainQubitIndex(getIndexByQubit(candidate));
+                int ibq = getIndexByQubit(candidate);
+                gate.setMainQubitIndex(ibq);
             } else {
                 continue;
             }

--- a/src/main/java/org/redfx/strange/Program.java
+++ b/src/main/java/org/redfx/strange/Program.java
@@ -140,21 +140,40 @@ public class Program {
             System.err.println("gate = "+gate);
             Qubit candidate = gate.getQubit();
             if (candidate != null) {
-                System.err.println("candidate = "+candidate);
-                if (this.qubits != null) {
-                    for (int i = 0; i < this.qubits.length; i++) {
-                        if (candidate.equals(this.qubits[i])) {
-                            System.err.println("this is qubit "+i);
-                            gate.setMainQubitIndex(i);
-                        }
-                    }
-                }
+                getIndexByQubit(candidate);
+                gate.setMainQubitIndex(getIndexByQubit(candidate));
+            } else {
+                continue;
+            }
+            candidate = gate.getSecondQubit();
+            if (candidate != null) {
+                getIndexByQubit(candidate);
+                gate.setAdditionalQubit(getIndexByQubit(candidate), 1);
+            } else {
+                continue;
+            }
+            candidate = gate.getThirdQubit();
+            if (candidate != null) {
+                getIndexByQubit(candidate);
+                gate.setAdditionalQubit(getIndexByQubit(candidate), 2);
+            } else {
+                continue;
             }
         }
         step.setIndex(steps.size());
         step.setProgram(this);
         steps.add(step);
         this.decomposedSteps = null;
+    }
+
+    private int getIndexByQubit(Qubit q) {
+        if (this.qubits == null) return -1;
+        for (int i = 0; i < this.qubits.length; i++) {
+            if (q.equals(this.qubits[i])) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/src/main/java/org/redfx/strange/gate/Cnot.java
+++ b/src/main/java/org/redfx/strange/gate/Cnot.java
@@ -35,6 +35,7 @@ package org.redfx.strange.gate;
 import org.redfx.strange.Complex;
 import org.redfx.strange.ControlledGate;
 import org.redfx.strange.Gate;
+import org.redfx.strange.Qubit;
 
 /**
  * <p>Cnot class.</p>
@@ -44,9 +45,9 @@ import org.redfx.strange.Gate;
  */
 public class Cnot extends TwoQubitGate implements ControlledGate {
     
-    private final Gate rootGate;
-    private final int rootGateIndex;
-    private final int controlIndex;
+    private Gate rootGate;
+    private int rootGateIndex;
+    private int controlIndex;
 
     Complex[][] matrix =  new Complex[][]{
         {Complex.ONE,Complex.ZERO,Complex.ZERO,Complex.ZERO},
@@ -66,6 +67,11 @@ public class Cnot extends TwoQubitGate implements ControlledGate {
         this.rootGateIndex = mainQubitIndex;
         this.controlIndex = controlQubitIndex;
         this.rootGate = new X(mainQubitIndex);
+    }
+
+    public Cnot(Qubit controlQubit, Qubit targetQubit) {
+        super(controlQubit, targetQubit);
+        this.rootGate = new X(0);
     }
 
     @Override public int getSize() {return 1;}
@@ -94,7 +100,11 @@ public class Cnot extends TwoQubitGate implements ControlledGate {
     public int getMainQubitIndex() {
         return this.rootGateIndex;
     }
-
+    @Override
+    public void setAdditionalQubit(int idx, int cnt) {
+        super.setAdditionalQubit(idx, cnt);
+        setMainQubitIndex(idx);
+    }
     @Override
     public Gate getRootGate() {
         return rootGate;

--- a/src/main/java/org/redfx/strange/gate/Hadamard.java
+++ b/src/main/java/org/redfx/strange/gate/Hadamard.java
@@ -33,6 +33,7 @@
 package org.redfx.strange.gate;
 
 import org.redfx.strange.Complex;
+import org.redfx.strange.Qubit;
 
 /**
  * <p>Hadamard class.</p>
@@ -53,6 +54,9 @@ public class Hadamard extends SingleQubitGate {
         super(idx);
     }
 
+    public Hadamard (Qubit q) {
+        super(q);
+    }
     /** {@inheritDoc} */
     @Override
     public Complex[][] getMatrix() {

--- a/src/main/java/org/redfx/strange/gate/SingleQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/SingleQubitGate.java
@@ -37,6 +37,7 @@ import org.redfx.strange.Gate;
 
 import java.util.Collections;
 import java.util.List;
+import org.redfx.strange.Qubit;
 
 /**
  *
@@ -48,13 +49,17 @@ import java.util.List;
 public abstract class SingleQubitGate implements Gate {
     
     protected int idx;
+    Qubit qubit;
     private boolean inverse;
     
     /**
      * <p>Constructor for SingleQubitGate.</p>
      */
     public SingleQubitGate() {}
-    
+
+    public SingleQubitGate(Qubit q) {
+        this.qubit = q;
+    }
     /**
      * <p>Constructor for SingleQubitGate.</p>
      *
@@ -62,6 +67,10 @@ public abstract class SingleQubitGate implements Gate {
      */
     public SingleQubitGate (int idx) {
         this.idx = idx;
+    }
+
+    public Qubit getQubit() {
+        return qubit;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/redfx/strange/gate/ThreeQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/ThreeQubitGate.java
@@ -37,6 +37,7 @@ import org.redfx.strange.Gate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.redfx.strange.Qubit;
 
 /**
  *
@@ -51,7 +52,11 @@ public abstract class ThreeQubitGate implements Gate {
     private int first;
     private int second;
     private int third;
-    
+
+    private Qubit mainQubit;
+    private Qubit secondQubit;
+    private Qubit thirdQubit;
+
     /**
      * <p>Constructor for ThreeQubitGate.</p>
      */
@@ -69,7 +74,28 @@ public abstract class ThreeQubitGate implements Gate {
         this.second = second;
         this.third = third;
     }
+    @Override
+    public Qubit getQubit() {
+        return mainQubit;
+    }
 
+    @Override
+    public Qubit getSecondQubit() {
+        return secondQubit;
+    }
+
+    @Override
+    public Qubit getThirdQubit() {
+        return thirdQubit;
+    }
+
+    public ThreeQubitGate (Qubit mainQubit, Qubit secondQubit, Qubit thirdQubit) {
+        this.mainQubit = mainQubit;
+        this.secondQubit = secondQubit;
+        this.thirdQubit = thirdQubit;
+    }
+
+    
     /** {@inheritDoc} */
     @Override
     public void setMainQubitIndex(int idx) {
@@ -106,7 +132,7 @@ public abstract class ThreeQubitGate implements Gate {
      *
      * @return a int
      */
-    public int getSecondQubit() {
+    public int getSecondQubitIndex() {
         return this.second;
     }
     
@@ -115,7 +141,7 @@ public abstract class ThreeQubitGate implements Gate {
      *
      * @return a int
      */
-    public int getThirdQubit() {
+    public int getThirdQubitIndex() {
         return this.third;
     }
         

--- a/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
@@ -36,6 +36,7 @@ import org.redfx.strange.Gate;
 
 import java.util.Arrays;
 import java.util.List;
+import org.redfx.strange.Qubit;
 
 /**
  *
@@ -51,6 +52,9 @@ public abstract class TwoQubitGate implements Gate {
     private int second;
     private int highest = -1;
     private boolean inverse;
+
+    private Qubit mainQubit;
+    private Qubit secondQubit;
     
     /**
      * <p>Constructor for TwoQubitGate.</p>
@@ -69,6 +73,22 @@ public abstract class TwoQubitGate implements Gate {
         this.highest = Math.max(first, second);
     }
 
+    @Override
+    public Qubit getQubit() {
+        return mainQubit;
+    }
+
+    @Override
+    public Qubit getSecondQubit() {
+        return secondQubit;
+    }
+
+    public TwoQubitGate (Qubit mainQubit, Qubit secondQubit) {
+        this.mainQubit = mainQubit;
+        this.secondQubit = secondQubit;
+    }
+
+    
     /** {@inheritDoc} */
     @Override
     public void setMainQubitIndex(int idx) {

--- a/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
+++ b/src/main/java/org/redfx/strange/gate/TwoQubitGate.java
@@ -93,6 +93,9 @@ public abstract class TwoQubitGate implements Gate {
     @Override
     public void setMainQubitIndex(int idx) {
         this.first = idx;
+        if (idx > highest) {
+            this.highest = idx;
+        }
     }
     
     /** {@inheritDoc} */
@@ -105,6 +108,9 @@ public abstract class TwoQubitGate implements Gate {
     @Override
     public void setAdditionalQubit(int idx, int cnt) {
         this.second = idx;
+        if (idx > highest) {
+            this.highest = idx;
+        }
     }
 
 

--- a/src/main/java/org/redfx/strange/gate/X.java
+++ b/src/main/java/org/redfx/strange/gate/X.java
@@ -33,6 +33,7 @@
 package org.redfx.strange.gate;
 
 import org.redfx.strange.Complex;
+import org.redfx.strange.Qubit;
 
 /**
  * <p>X class.</p>
@@ -51,6 +52,10 @@ public class X extends SingleQubitGate {
      */
     public X (int idx) {
         super(idx);
+    }
+
+    public X(Qubit q) {
+        super(q);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/redfx/strange/local/Computations.java
+++ b/src/main/java/org/redfx/strange/local/Computations.java
@@ -208,8 +208,8 @@ public class Computations {
             } else if (gate instanceof ThreeQubitGate) {
                 ThreeQubitGate tqg = (ThreeQubitGate) gate;
                 int first = tqg.getMainQubit();
-                int second = tqg.getSecondQubit();
-                int third = tqg.getThirdQubit();
+                int second = tqg.getSecondQubitIndex();
+                int third = tqg.getThirdQubitIndex();
                 int sFirst = first;
                 int sSecond = second;
                 int sThird = third;

--- a/src/main/java/org/redfx/strange/local/SimpleQuantumExecutionEnvironment.java
+++ b/src/main/java/org/redfx/strange/local/SimpleQuantumExecutionEnvironment.java
@@ -155,7 +155,7 @@ public class SimpleQuantumExecutionEnvironment implements QuantumExecutionEnviro
             PermutationGate pg = (PermutationGate)gates.get(0);
             return Computations.permutateVector (vector, pg.getIndex1(), pg.getIndex2());
         }
-      
+
         Complex[] result = new Complex[vector.length];
         boolean vdd = true;
         result = Computations.calculateNewState(gates, vector, qubits.length);

--- a/src/test/java/org/redfx/strange/test/BellStateTest.java
+++ b/src/test/java/org/redfx/strange/test/BellStateTest.java
@@ -93,6 +93,29 @@ public class BellStateTest extends BaseGateTests {
         assertTrue(zeroCount < RUNS);
     }
 
+    @Test
+    public void multimeasurementNamedQubit() {
+        Qubit controlQubit = new Qubit();
+        Qubit targetQubit = new Qubit();
+        Program p = new Program(controlQubit, targetQubit);
+        p.addSteps(new Step(new Hadamard(controlQubit)),
+            new Step(new Cnot(targetQubit, controlQubit))
+        );
+        Result res = runProgram(p);
+        int zeroCount = 0;
+        final int RUNS = 100;
+        for (int i = 0; i < 100; i++) {
+            res.measureSystem();
+            Qubit[] qubits = res.getQubits();
+            int q0 = qubits[0].measure();
+            int q1 = qubits[1].measure();
+            assertEquals(q0,q1);
+            if (q0 == 0) zeroCount++;
+        }
+        assertTrue(zeroCount > 0);
+        assertTrue(zeroCount < RUNS);
+    }
+
     /**
      * BellState with a third qubit that is sent through a H gate
      */

--- a/src/test/java/org/redfx/strange/test/SingleQubitGateTests.java
+++ b/src/test/java/org/redfx/strange/test/SingleQubitGateTests.java
@@ -32,6 +32,7 @@
  */
 package org.redfx.strange.test;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -53,7 +54,31 @@ public class SingleQubitGateTests extends BaseGateTests {
     @Test
     public void empty() {
     }
-        
+
+    @Test
+    public void namedQubit() {
+        Qubit q0 = new Qubit();
+        Program p = new Program(q0);
+        X x = new X(q0);
+        p.addStep(new Step(x));
+
+        Result res = runProgram(p);
+        Complex[] probs = res.getProbability();
+        System.err.println("probs = "+Arrays.toString(probs));
+    }
+
+    @Test
+    public void namedQubit2() {
+        Qubit q0 = new Qubit();
+        Qubit q1 = new Qubit();
+        Program p = new Program(q0, q1);
+        X x = new X(q0);
+        p.addSteps(new Step(x), new Step(new X(q1)));
+
+        Result res = runProgram(p);
+        Complex[] probs = res.getProbability();
+        System.err.println("probs = "+Arrays.toString(probs));
+    }
     @Test
     public void simpleIGate() {
         Program p = new Program(1, new Step(new Identity(0)));


### PR DESCRIPTION
Instead of referring to qubits by their index, this PR allows to refer to qubits using their assigned name.

Fix #195 

This allows to create applications like this:

```
import org.redfx.strange.*;
import org.redfx.strange.gate.*;
import org.redfx.strange.local.SimpleQuantumExecutionEnvironment;
import java.util.Arrays;

public class ShortStrangeDemo {
    public static void main(String[] args) {
        Qubit controlQubit = new Qubit();
        Qubit targetQubit = new Qubit();
        Program p = new Program(controlQubit, targetQubit);
        p.addSteps(new Step(new Hadamard(controlQubit)), new Step(new Cnot(controlQubit, targetQubit)));
        SimpleQuantumExecutionEnvironment sqee = new SimpleQuantumExecutionEnvironment();
        Qubit[] qubits = sqee.runProgram(p).getQubits();
        Arrays.asList(qubits).forEach(q -> System.out.println("qubit with probability on 1 = "+q.getProbability()+", measured it gives "+ q.measure()));
    }
}
```

